### PR TITLE
Force read val of function to be float value.

### DIFF
--- a/ADPedit/Actual Code.cs
+++ b/ADPedit/Actual Code.cs
@@ -114,7 +114,7 @@ namespace ADPedit
                         }
                         else
                         {
-                            bw.Write((float) adp.ADPfuncVal);
+                            bw.Write(adp.ADPfuncVal);
                         }
                     }
                     bw.Write(0x00);

--- a/ADPedit/Actual Code.cs
+++ b/ADPedit/Actual Code.cs
@@ -42,12 +42,12 @@ namespace ADPedit
                         var FinalFunc = new adpFunc() //make a new adp function and store it in the FinalFunc var so it can be used in funcDetect
                         {
                             TimeID = br.ReadUInt32(),
-                            timeSecondsMarker = br.ReadSingle(),
+                            timeSecondsMarker = (float) br.ReadSingle()*1.0f,
                             unk = br.ReadInt32(),
                             frameTime = br.ReadInt32(),
                             padding = br.ReadDouble(),
                             ADPfuncID = br.ReadUInt32(),
-                            ADPfuncVal = br.ReadSingle(),
+                            ADPfuncVal = (float) br.ReadSingle()*1.0f,
                             ADPfuncName = null,
                         };
                         FuncDetect(FinalFunc); //push FinalFunc into funcDetect
@@ -114,7 +114,7 @@ namespace ADPedit
                         }
                         else
                         {
-                            bw.Write(adp.ADPfuncVal);
+                            bw.Write((float) adp.ADPfuncVal);
                         }
                     }
                     bw.Write(0x00);


### PR DESCRIPTION
Without this, it's easy to broke the float val in the file after 1 or 2 save, depending of where and what are the float values in the file.
Just to be sure, multiplying the val by 1.0f, just in case some values with 0 like -0.1 have issue. I didn't tested without.